### PR TITLE
60 prettier integration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  extends: 'airbnb-base',
+  extends: ['airbnb-base', 'prettier'],
   env: {
     browser: true,
   },

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "chai": "4.3.7",
         "eslint": "8.35.0",
         "eslint-config-airbnb-base": "15.0.0",
+        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "2.27.5",
         "sinon": "15.0.1",
         "stylelint": "15.2.0",
@@ -2558,6 +2559,18 @@
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -8990,6 +9003,13 @@
         "object.entries": "^1.1.5",
         "semver": "^6.3.0"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   "devDependencies": {
     "@babel/core": "7.21.0",
     "@babel/eslint-parser": "7.19.1",
-    "chai": "4.3.7",
-    "eslint": "8.35.0",
-    "eslint-config-airbnb-base": "15.0.0",
-    "eslint-plugin-import": "2.27.5",
     "@esm-bundle/chai": "4.3.4-fix.0",
     "@web/test-runner": "0.15.1",
     "@web/test-runner-commands": "0.6.5",
+    "chai": "4.3.7",
+    "eslint": "8.35.0",
+    "eslint-config-airbnb-base": "15.0.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "2.27.5",
     "sinon": "15.0.1",
     "stylelint": "15.2.0",
     "stylelint-config-standard": "30.0.1"


### PR DESCRIPTION
Fix #60

This enables the use of the Prettier code formatter with rules defined at project level. It also extends ESLint plugins with a dedicated `prettier` plugin config that disables a bunch of core and plugin rules that interfere with Prettier.

Test URLs:

- Before: https://main--durysta--hlxsites.hlx.page/
- After: https://60-prettier-integration--durysta--hlxsites.hlx.page/

Note: don't forget to run `npm i` after the deployment.
