### PR TITLE
74 mobile images

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -49,6 +49,18 @@
   overflow-x: hidden;
 }
 
+.section.columns-slide-image-from-left-container {
+  overflow-x: hidden;
+}
+
+.columns.slide-image-from-left :is(.columns-left, .columns-single) {
+  width: 100%;
+}
+
+.columns.slide-image-from-right :is(.columns-right, .columns-single) {
+  width: 100%;
+}
+
 .columns.slide-image-from-left
   :is(.columns-left, .columns-single)
   :is(img) {
@@ -88,6 +100,14 @@
 
   .columns.slide-image-from-right > div {
     align-items: end;
+  }
+
+  .columns.slide-image-from-left :is(.columns-left, .columns-single) {
+    width: unset;
+  }
+  
+  .columns.slide-image-from-right :is(.columns-right, .columns-single) {
+    width: unset;
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,12 +32,32 @@ function buildSectionDivider(main) {
 }
 
 /**
+ * Builds a media-dependent picture
+ * @param {Element} main The container element
+ */
+function buildMediaDependentPicture(main) {
+  const mediaTags = main.querySelectorAll('code');
+
+  mediaTags.forEach((el) => {
+    const alt = el.innerText.trim();
+    const lower = alt.toLowerCase();
+    const mediaTypes = ['mobile', 'tablet', 'laptop', 'desktop', 'hd', 'tablet-plus', 'laptop-plus', 'desktop-plus', 'tablet-minus', 'laptop-minus', 'desktop-minus'];
+    if (mediaTypes.includes(lower)) {
+      el.previousElementSibling.classList.add(`media-${lower}`);
+      el.innerText = '';
+      el.remove();
+    }
+  });
+}
+
+/**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
  */
 function buildAutoBlocks(main) {
   try {
     buildSectionDivider(main);
+    buildMediaDependentPicture(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -192,6 +192,10 @@
   --scrollbar-width: 10px;
 }
 
+.media-tablet, .media-laptop, .media-desktop, .media-hd, .media-tablet-plus, .media-laptop-plus, .media-desktop-plus {
+  display: none;
+}
+
 /* tablet break point */
 @media (min-width: 768px) {
    :root {
@@ -203,12 +207,28 @@
     --heading-font-size-xs: 16px;
     --body-line-height: 1.33;
   }
+
+  .media-mobile {
+    display: none;
+  }
+
+  .media-tablet, .media-tablet-plus {
+    display: unset;
+  }
 }
 
 /* laptop break point */
 @media (min-width: 992px) {
   :root {
     --nav-height: var(--nav-height-laptop);
+  }
+
+  .media-tablet, .media-tablet-minus {
+    display: none;
+  }
+
+  .media-laptop, .media-laptop-plus {
+    display: unset;
   }
 }
 
@@ -217,12 +237,28 @@
   :root {
     --nav-height: var(--nav-height-desktop);
   }
+
+  .media-laptop, .media-laptop-minus {
+    display: none;
+  }
+
+  .media-desktop, .media-laptop-desktop {
+    display: unset;
+  }
 }
 
 /* hd break point */
 @media (min-width: 1366px) {
   :root {
     --nav-height: var(--nav-height-hd);
+  }
+
+  .media-desktop, .media-desktop-minus {
+    display: none;
+  }
+
+  .media-hd {
+    display: unset;
   }
 }
 


### PR DESCRIPTION
Fix #74

Allows media type tags in the document to control visibility of the tagged element.

Test URLs:
- Before: https://main--durysta--hlxsites.hlx.page
- After: https://74-mobile-images--durysta--hlxsites.hlx.page/drafts/rootpea/draft

<img width="666" alt="Screenshot 2023-07-08 at 00 26 32" src="https://github.com/hlxsites/durysta/assets/52969899/c61b513f-b586-4a5b-a2ea-1eda9757799b">

