### PR TITLE
87 - sliding images are on the bottom of their rows

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -26,7 +26,7 @@
 
 @media (min-width: 768px) {
   .columns > div {
-    align-items: start;
+    align-items: stretch;
     flex-direction: unset;
     gap: 32px;
   }
@@ -94,14 +94,6 @@
 }
 
 @media (min-width: 768px) {
-  .columns.slide-image-from-left > div {
-    align-items: stretch;
-  }
-
-  .columns.slide-image-from-right > div {
-    align-items: stretch;
-  }
-
   .columns.slide-image-from-left :is(.columns-left, .columns-single) {
     width: unset;
     align-self: flex-end;

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -95,19 +95,29 @@
 
 @media (min-width: 768px) {
   .columns.slide-image-from-left > div {
-    align-items: end;
+    align-items: stretch;
   }
 
   .columns.slide-image-from-right > div {
-    align-items: end;
+    align-items: stretch;
   }
 
   .columns.slide-image-from-left :is(.columns-left, .columns-single) {
     width: unset;
   }
-  
+
   .columns.slide-image-from-right :is(.columns-right, .columns-single) {
     width: unset;
+  }
+
+  .columns.slide-image-from-left :is(.columns-left, .columns-single) :is(img) {
+    position: absolute;
+    bottom: 0px;
+  }
+
+  .columns.slide-image-from-right :is(.columns-right, .columns-single) :is(img) {
+    position: absolute;
+    bottom: 0px;
   }
 }
 

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -104,20 +104,12 @@
 
   .columns.slide-image-from-left :is(.columns-left, .columns-single) {
     width: unset;
+    align-self: flex-end;
   }
 
   .columns.slide-image-from-right :is(.columns-right, .columns-single) {
     width: unset;
-  }
-
-  .columns.slide-image-from-left :is(.columns-left, .columns-single) :is(img) {
-    position: absolute;
-    bottom: 0;
-  }
-
-  .columns.slide-image-from-right :is(.columns-right, .columns-single) :is(img) {
-    position: absolute;
-    bottom: 0;
+    align-self: flex-end;
   }
 }
 

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -112,12 +112,12 @@
 
   .columns.slide-image-from-left :is(.columns-left, .columns-single) :is(img) {
     position: absolute;
-    bottom: 0px;
+    bottom: 0;
   }
 
   .columns.slide-image-from-right :is(.columns-right, .columns-single) :is(img) {
     position: absolute;
-    bottom: 0px;
+    bottom: 0;
   }
 }
 


### PR DESCRIPTION
sliding images are on the bottom of their rows, but the rest of the row content is aligned on top

Fix #87

Test URLs:
- Before: https://main--durysta--hlxsites.hlx.page
- After: https://87-sliding-bottom--durysta--hlxsites.hlx.page
